### PR TITLE
JogAmp 2.0.2-rc12 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <url>https://github.com/brandonborkholder/glg2d</url>
   </scm>
   <properties>
-    <jogl.version>2.0-rc11</jogl.version>
+    <jogl.version>2.0.2-rc12</jogl.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>

--- a/src/main/java/org/jogamp/glg2d/event/NewtMouseEventTranslator.java
+++ b/src/main/java/org/jogamp/glg2d/event/NewtMouseEventTranslator.java
@@ -71,7 +71,7 @@ public class NewtMouseEventTranslator extends MouseEventTranslator implements Mo
     int id = newtType2Awt(e.getEventType());
     int modifiers = newtModifiers2Awt(e.getModifiers());
     long when = e.getWhen();
-    int wheelRotation = -e.getWheelRotation();
+    int wheelRotation = Math.round(-e.getRotation()[0]);
     publishMouseWheelEvent(id, when, modifiers, wheelRotation, new Point(e.getX(), e.getY()));
   }
 

--- a/src/test/java/org/jogamp/glg2d/newt/NewtPeer.java
+++ b/src/test/java/org/jogamp/glg2d/newt/NewtPeer.java
@@ -20,6 +20,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.PaintEvent;
+import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
@@ -101,8 +102,8 @@ public class NewtPeer implements WindowPeer {
   }
 
   @Override
-  public void setAlwaysOnTop(boolean alwaysOnTop) {
-    notImplemented("EmptyWindowPeer.setAlwaysOnTop");
+  public void updateAlwaysOnTopState() {
+    notImplemented("EmptyWindowPeer.updateAlwaysOnTopState");
   }
 
   @Override
@@ -136,7 +137,7 @@ public class NewtPeer implements WindowPeer {
   }
 
   @Override
-  public void updateWindow() {
+  public void updateWindow(BufferedImage arg0) {
     notImplemented("EmptyWindowPeer.updateWindow");
   }
 


### PR DESCRIPTION
pom.xml: Update jogl.version to 2.0.2-rc12

NewtMouseEventTranslator: Update for Newt/MouseEvent API change.
https://github.com/JogAmp/jogl/commit/ded080fd890c21b54ba1f96d84f9e355711dc88a

NewtPeer: Fix build by update stubs according to WindowPeer interface.

Signed-off-by: Xerxes Rånby xerxes@zafena.se
