### PR TITLE
Minor fixes to path drawing (exception on empty paths and moveTo)

### DIFF
--- a/src/main/java/org/jogamp/glg2d/GLG2DCanvas.java
+++ b/src/main/java/org/jogamp/glg2d/GLG2DCanvas.java
@@ -264,7 +264,7 @@ public class GLG2DCanvas extends JComponent {
    * though it is disabled. A {@code GLJPanel} supports this better.
    */
   protected GLAutoDrawable createGLComponent(GLCapabilitiesImmutable capabilities, GLContext shareWith) {
-    GLCanvas canvas = new GLCanvas(capabilities, shareWith);
+    GLCanvas canvas = new GLCanvas(capabilities);
     canvas.setEnabled(false);
     chosenCapabilities = (GLCapabilitiesImmutable) capabilities.cloneMutable();
     return canvas;
@@ -314,7 +314,7 @@ public class GLG2DCanvas extends JComponent {
   private void prepareSideContext() {
     if (sideContext == null) {
       GLDrawableFactory factory = canvas.getFactory();
-      sideContext = factory.createOffscreenAutoDrawable(null, chosenCapabilities, null, 1, 1, canvas.getContext());
+      sideContext = factory.createOffscreenAutoDrawable(null, chosenCapabilities, null, 1, 1);
       sideContext.addGLEventListener(g2dglListener);
     }
 

--- a/src/main/java/org/jogamp/glg2d/GLG2DSimpleEventListener.java
+++ b/src/main/java/org/jogamp/glg2d/GLG2DSimpleEventListener.java
@@ -71,7 +71,7 @@ public class GLG2DSimpleEventListener implements GLEventListener {
    * Defines the viewport to paint into.
    */
   protected void setupViewport(GLAutoDrawable drawable) {
-    drawable.getGL().glViewport(0, 0, drawable.getWidth(), drawable.getHeight());
+    drawable.getGL().glViewport(0, 0, drawable.getSurfaceWidth(), drawable.getSurfaceHeight());
   }
 
   /**

--- a/src/main/java/org/jogamp/glg2d/impl/GLGraphicsConfiguration.java
+++ b/src/main/java/org/jogamp/glg2d/impl/GLGraphicsConfiguration.java
@@ -90,7 +90,7 @@ public class GLGraphicsConfiguration extends GraphicsConfiguration {
 
   @Override
   public Rectangle getBounds() {
-    return new Rectangle(target.getWidth(), target.getHeight());
+    return new Rectangle(target.getSurfaceWidth(), target.getSurfaceHeight());
   }
 
   public GLDrawable getTarget() {

--- a/src/main/java/org/jogamp/glg2d/impl/SimpleOrTesselatingVisitor.java
+++ b/src/main/java/org/jogamp/glg2d/impl/SimpleOrTesselatingVisitor.java
@@ -276,8 +276,10 @@ public class SimpleOrTesselatingVisitor extends SimplePathVisitor {
 
     float[] vertex = new float[2];
 
-    buf.get(vertex);
-    visitor.moveTo(vertex);
+    if (buf.hasRemaining()) {
+	    buf.get(vertex);
+	    visitor.moveTo(vertex);
+    }
 
     while (buf.hasRemaining()) {
       buf.get(vertex);

--- a/src/main/java/org/jogamp/glg2d/impl/gl2/FastLineVisitor.java
+++ b/src/main/java/org/jogamp/glg2d/impl/gl2/FastLineVisitor.java
@@ -162,6 +162,8 @@ public class FastLineVisitor extends SimplePathVisitor {
       buf.position(p);
       buffer.drawBuffer(gl, GL2.GL_POINTS);
     }
+    
+    buffer.clear();
   }
 
   @Override

--- a/src/main/java/org/jogamp/glg2d/impl/shader/GeometryShaderStrokePipeline.java
+++ b/src/main/java/org/jogamp/glg2d/impl/shader/GeometryShaderStrokePipeline.java
@@ -179,9 +179,9 @@ public class GeometryShaderStrokePipeline extends AbstractShaderPipeline {
     super.attachShaders(gl);
 
     GL2GL3 gl3 = gl.getGL2GL3();
-    gl3.glProgramParameteri(programId, GL2GL3.GL_GEOMETRY_INPUT_TYPE_ARB, GL.GL_LINES);
-    gl3.glProgramParameteri(programId, GL2GL3.GL_GEOMETRY_OUTPUT_TYPE_ARB, GL.GL_TRIANGLE_STRIP);
-    gl3.glProgramParameteri(programId, GL2GL3.GL_GEOMETRY_VERTICES_OUT_ARB, maxVerticesOut);
+    gl3.glProgramParameteriARB(programId, GL2GL3.GL_GEOMETRY_INPUT_TYPE_ARB, GL.GL_LINES);
+    gl3.glProgramParameteriARB(programId, GL2GL3.GL_GEOMETRY_OUTPUT_TYPE_ARB, GL.GL_TRIANGLE_STRIP);
+    gl3.glProgramParameteriARB(programId, GL2GL3.GL_GEOMETRY_VERTICES_OUT_ARB, maxVerticesOut);
   }
 
   @Override

--- a/src/test/java/org/jogamp/glg2d/ImageTest.java
+++ b/src/test/java/org/jogamp/glg2d/ImageTest.java
@@ -42,8 +42,7 @@ public class ImageTest {
     GLCapabilities caps = GLG2DCanvas.getDefaultCapabalities();
     caps.setFBO(true);
     caps.setOnscreen(false);
-    GLAutoDrawable offscreen = GLDrawableFactory.getFactory(GLProfile.getGL2ES1()).createOffscreenAutoDrawable(null, caps, null, size, size,
-        null);
+    GLAutoDrawable offscreen = GLDrawableFactory.getFactory(GLProfile.getGL2ES1()).createOffscreenAutoDrawable(null, caps, null, size, size);
 
     JComponent comp = createComponent();
 


### PR DESCRIPTION
I found glg2d to be incompatible with my JOGL version (2.2.4). I fixed this.

The next thing I noticed is, that moveTo() for paths only draws the path as far as it is, but it does not discard the draw buffer, thus drawing the whole line and the moveTo() line the next time.

There also was an error when trying to draw empty areas.