### PR TITLE
ensureCapacity() and SimpleOrTesselatingVisitor#moveTo fix.

### DIFF
--- a/src/main/java/org/jogamp/glg2d/VertexBuffer.java
+++ b/src/main/java/org/jogamp/glg2d/VertexBuffer.java
@@ -110,7 +110,7 @@ public class VertexBuffer {
 
   protected void ensureCapacity(int numNewFloats) {
     if (buffer.capacity() <= buffer.position() + numNewFloats) {
-      FloatBuffer larger = Buffers.newDirectFloatBuffer(buffer.position() * 2);
+      FloatBuffer larger = Buffers.newDirectFloatBuffer(Math.max(buffer.position() * 2, buffer.position() + numNewFloats));
       deviceBufferId = -deviceBufferId;
       int position = buffer.position();
       buffer.rewind();

--- a/src/main/java/org/jogamp/glg2d/impl/SimpleOrTesselatingVisitor.java
+++ b/src/main/java/org/jogamp/glg2d/impl/SimpleOrTesselatingVisitor.java
@@ -124,7 +124,7 @@ public class SimpleOrTesselatingVisitor extends SimplePathVisitor {
     if (firstContour) {
       firstContour = false;
     } else if (isConvexSoFar) {
-      setUseTesselator(true);
+      setUseTesselator(false);
     }
 
     if (isConvexSoFar) {
@@ -134,6 +134,7 @@ public class SimpleOrTesselatingVisitor extends SimplePathVisitor {
       buffer.clear();
       buffer.addVertex(vertex[0], vertex[1]);
     } else {
+      tesselatorFallback.closeLine();
       tesselatorFallback.moveTo(vertex);
     }
   }


### PR DESCRIPTION
ensureCapacity() currently only works for small increments in capacity.

SimpleOrTesselatingVisitor bad a bug on a moveTo.

(work from my GSoC project: Accellerating JOSM by using OpenGL)