### PR TITLE
Support setting antialiasing hints to null

### DIFF
--- a/src/main/java/org/jogamp/glg2d/GLGraphics2D.java
+++ b/src/main/java/org/jogamp/glg2d/GLGraphics2D.java
@@ -313,7 +313,9 @@ public class GLGraphics2D extends Graphics2D implements Cloneable {
 
   @Override
   public void setRenderingHint(Key hintKey, Object hintValue) {
-    if (!hintKey.isCompatibleValue(hintValue)) {
+    if (hintValue == null) {
+      hints.remove(hintKey);
+    } else if (!hintKey.isCompatibleValue(hintValue)) {
       throw new IllegalArgumentException(hintValue + " is not compatible with " + hintKey);
     } else {
       for (G2DDrawingHelper helper : helpers) {

--- a/src/main/java/org/jogamp/glg2d/impl/AbstractTextDrawer.java
+++ b/src/main/java/org/jogamp/glg2d/impl/AbstractTextDrawer.java
@@ -56,7 +56,7 @@ public abstract class AbstractTextDrawer implements GLG2DTextHelper {
   @Override
   public void setHint(Key key, Object value) {
     if (key == RenderingHints.KEY_TEXT_ANTIALIASING) {
-      stack.peek().antiAlias = value == RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
+      stack.peek().antiAlias = value != null && value != RenderingHints.VALUE_TEXT_ANTIALIAS_OFF && value != RenderingHints.VALUE_TEXT_ANTIALIAS_DEFAULT;
     }
   }
 


### PR DESCRIPTION
It is currently not possible to call `setRenderingHint(key, null)`. This causes issues when using `GLGraphics2D` with Flying Saucer (https://github.com/flyingsaucerproject/flyingsaucer), as it is using following pattern:

       // set
       Object aaHint = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
       graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, antiAliasRenderingHint );

       // restore
       graphics.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, aaHint );

As there are no hints by default, the initial value for all hints when queried is `null`. Not accepting `null` in  `getRenderingHint` makes restoring initial value impossible.